### PR TITLE
add custom repo lower on channel priorities

### DIFF
--- a/envs/metrics.yaml
+++ b/envs/metrics.yaml
@@ -1,8 +1,8 @@
 name: metrics
 channels:
-  - https://repo.prefix.dev/almost-conductor
   - conda-forge
   - bioconda
+  - https://repo.prefix.dev/almost-conductor
   - nodefaults
 dependencies:
   - python >=3.12

--- a/envs/r.yml
+++ b/envs/r.yml
@@ -1,9 +1,9 @@
 ---
 name: r_conda
 channels:
-  - https://prefix.dev/almost-conductor
   - conda-forge
   - bioconda
+  - https://prefix.dev/almost-conductor
 dependencies:
   - r-base=4.5.3
   - bioconductor-edger >= 4.8.0

--- a/envs/scrapper.yml
+++ b/envs/scrapper.yml
@@ -1,8 +1,8 @@
 name: scrapper
 channels:
-- https://prefix.dev/almost-conductor
 - conda-forge
 - bioconda
+- https://prefix.dev/almost-conductor
 - nodefaults
 dependencies:
 - r-base >=4.5


### PR DESCRIPTION
lower the priority for the prefix-dev channel.

original problem was that rattler-build does not pin an older GLIBC - that should be the more forward-looking fix.

can be reproduced by running just the data stage in hainan (h5lib was picked from prefix channel, triggering glibc compat issue).

- Closes: #32 